### PR TITLE
fix: SVG attributes parsing regular expression to include hyphen symbol

### DIFF
--- a/layouts/partials/icons/functions/svg-attrs.html
+++ b/layouts/partials/icons/functions/svg-attrs.html
@@ -6,7 +6,7 @@
 {{- $attrs.Set "fill" "currentColor" -}}
 {{- $attrs.Set "aria-hidden" "true" -}}
 {{/* Parse the attributes' name="value" pairs. */}}
-{{- range findRE `\w+="[^"]+"` (index $tag 0) -}}
+{{- range findRE `[\w-]+="[^"]+"` (index $tag 0) -}}
   {{- $pair := split . "=" -}}
   {{- $name := index $pair 0 -}}
   {{- $val := replace (index $pair 1) `"` "" -}}


### PR DESCRIPTION
Fixes #295 