### PR TITLE
feat: add the `throw_on_error` parameter, default to `true`

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,8 @@
 [module.hugoVersion]
 min = "0.110.0"
 
+[params.icons]
+throw_on_error = true # throw an error instead of a warning if icon not found.
+
 # [params.icons.vendors.shorthand]
 # name = "full name of vendor"

--- a/layouts/partials/icons/icon.html
+++ b/layouts/partials/icons/icon.html
@@ -15,7 +15,11 @@
 {{- $res := dict "vendor" $vendor "name" $name }}
 {{- $icon := partialCached "icons/functions/svg-resource" $res $res -}}
 {{- if not $icon -}}
-  {{- warnf "[icons] %s's %s doesn't exist." $vendor $name -}}
+  {{- if default true site.Params.icons.throw_on_error }}
+    {{- errorf "[icons] %s's %s doesn't exist." $vendor $name }}
+  {{- else }}
+    {{- warnf "[icons] %s's %s doesn't exist." $vendor $name -}}
+  {{- end }}
 {{- end -}}
 {{- with $icon -}}
   {{- $size := default "1em" $.size }}


### PR DESCRIPTION
When `true`, throw an error instead of a warning if icon not found.

Closes #436